### PR TITLE
check no on stdout task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
   set_fact:
     dhparam_openssl_binary: "{{which_openssl_output.stdout_lines[0]}}"
   no_log: true
+  check_mode: no
 
 - name: Output directory for Diffie-Hellman parameters exists
   file:


### PR DESCRIPTION
This task fails when --check is enabled due to it requiring stdout.

This will just skip the task when check is being used