### PR TITLE
CentOS support and other fixes/changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ Role Variables
 | dhparam_file            | no       | `/etc/ssl/certs/dhparam-{{dhparam_size}}.pem` |
 | dhparam_update_enabled  | no       | false                                         |
 | dhparam_update_interval | no       | `weekly`                                      |
+| dhparam_entropy_service | no       | false                                         |
+
+Entropy Service
+---------------
+In virtual machine environements or bare metal hardware that is heavily utilized, generating
+high bit-rate cryptographic data sets can deplete the available entropy (random data). This
+results in the generation process stalling out while waiting on more entropy to become
+available. It is not uncommon on a virtual machine to have as low as a 1024 bit Diffie-Hellman
+run take 1-5 minutes and larger bit rates taking considerably longer.
+
+The use of an entropy service, haveged on Debian and rngd on RedHat, resolves this by using the
+non-blocking /dev/urandom to supply a constant stream of random data. The consequence of which
+is that some of that data may be reused existing entropy, making it suboptimal for long-term
+cryotgraphic keys (read: regenerate the data regularly).
+
+As such, on virtual machines or high utilization bare metal systems, it is recommended to enable
+the dhparam_entropy_service along with dhparam_update_enabled.
 
 Examples
 --------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 dhparam_size: 4096
-dhparam_file: "/etc/ssl/dhparam-{{ dhparams_size }}.pem"
+dhparam_file: "/etc/ssl/dhparam-{{ dhparam_size }}.pem"
 
 # Use a cronjob to update DH params regularly
 dhparam_update_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,5 +5,10 @@ dhparam_file: "/etc/ssl/dhparam-{{ dhparam_size }}.pem"
 
 # Use a cronjob to update DH params regularly
 dhparam_update_enabled: false
+
 # (daily, weekly, monthly, annually)
 dhparam_update_interval: weekly
+
+# install service to maintain constant entropy data pool; Debian/Ubuntu = haveged, RedHat/CentOS = rngd 
+# see README.md for details on entropy services
+dhparam_entropy_service: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,8 +6,12 @@ galaxy_info:
   description: Generates Diffie-Hellman Parameters (dhparam)
   company: gronke.org
   license: MIT
-  min_ansible_version: 1.9
+  min_ansible_version: 2.0
   platforms:
+    - name: EL
+      versions:
+      - 6
+      - 7
     - name: FreeBSD
       versions:
         - 9.3

--- a/tasks/entropy.yml
+++ b/tasks/entropy.yml
@@ -1,0 +1,21 @@
+---
+
+  - name: Install rng toolkit
+    yum: name=rng-tools state=present
+    when: ansible_os_family == "RedHat"
+
+  - name: Modify rngd configuration to point to /dev/urandom
+    template: src=etc/sysconfig/rngd.j2 dest=/etc/sysconfig/rngd owner=root group=root mode=0640
+    when: ansible_os_family == "RedHat"
+
+  - name: Start the rngd service
+    service: name=rngd enabled=yes state=restarted
+    when: ansible_os_family == "RedHat"
+
+  - name: Install haveged daemon
+    apt: name=haveged state=present
+    when: (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+
+  - name: Start the haveged service
+    service: name=haveged enabled=yes state=restarted
+    when: (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')

--- a/tasks/install.centos.yml
+++ b/tasks/install.centos.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Ensure openssl is installed.
+  yum:
+    name: "openssl"
+    state: installed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,3 +5,6 @@
 
 - include: install.debian.yml
   when: (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+
+- include: install.centos.yml
+  when: (ansible_distribution == 'CentOS') or (ansible_distribution == 'Red Hat Enterprise Linux')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     - entropy-service
 
 - name: The Diffie-Hellman parameter file is generated
-  command: "{{dhparam_openssl_binary}} dhparam -out '{{ dhparam_file }}' {{ dhparam_size }}"
+  command: "{{dhparam_openssl_binary}} dhparam -dsaparam -out '{{ dhparam_file }}' {{ dhparam_size }}"
   args:
     creates: "{{ dhparam_file }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,14 +12,15 @@
     dhparam_openssl_binary: "{{which_openssl_output.stdout_lines[0]}}"
   no_log: true
 
-#- name: Output directory for Diffie-Hellman parameters exists
-#  file:
-#    path: "{{ dhparam_file | dirname }}"
-#    state: directory
-
 - name: The Diffie-Hellman parameter file is generated
   command: "{{dhparam_openssl_binary}} dhparam -out '{{ dhparam_file }}' {{ dhparam_size }}"
   args:
     creates: "{{ dhparam_file }}"
+
+- include: entropy.yml
+  when: dhparam_entropy_service
+  tags:
+    - setup-entropy
+    - entropy-service
 
 - include: cron.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,10 @@
     dhparam_openssl_binary: "{{which_openssl_output.stdout_lines[0]}}"
   no_log: true
 
-- name: Output directory for Diffie-Hellman parameters exists
-  file:
-    path: "{{ dhparam_file | dirname }}"
-    state: directory
+#- name: Output directory for Diffie-Hellman parameters exists
+#  file:
+#    path: "{{ dhparam_file | dirname }}"
+#    state: directory
 
 - name: The Diffie-Hellman parameter file is generated
   command: "{{dhparam_openssl_binary}} dhparam -out '{{ dhparam_file }}' {{ dhparam_size }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,15 +12,15 @@
     dhparam_openssl_binary: "{{which_openssl_output.stdout_lines[0]}}"
   no_log: true
 
-- name: The Diffie-Hellman parameter file is generated
-  command: "{{dhparam_openssl_binary}} dhparam -out '{{ dhparam_file }}' {{ dhparam_size }}"
-  args:
-    creates: "{{ dhparam_file }}"
-
 - include: entropy.yml
   when: dhparam_entropy_service
   tags:
     - setup-entropy
     - entropy-service
+
+- name: The Diffie-Hellman parameter file is generated
+  command: "{{dhparam_openssl_binary}} dhparam -out '{{ dhparam_file }}' {{ dhparam_size }}"
+  args:
+    creates: "{{ dhparam_file }}"
 
 - include: cron.yml

--- a/templates/etc/sysconfig/rngd.j2
+++ b/templates/etc/sysconfig/rngd.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+# Add extra options here
+EXTRAOPTIONS="-r /dev/urandom"


### PR DESCRIPTION
[Fix] dhparam_file default value contains typo in dhparam_size
[Change] added EL6/7 support
[Change] removed requirement on exclusive directory structure for dhparam
[New] added dhparam_entropy_service for installation of haveged on Debian and rngd on RedHat
[New] added entropy service section to README.md explaining entropy services pro/con
[Change] reorder tasks so that entropy service installs if enabled before dhparams generates
[Change] add '-dsaparam' to OpenSSL generation of DH parameters file; reduces run time significantly at no material loss of security
ref: https://security.stackexchange.com/questions/54359/what-is-the-difference-between-diffie-hellman-generator-2-and-5
ref2: https://security.stackexchange.com/questions/95178/diffie-hellman-parameters-still-calculating-after-24-hours